### PR TITLE
feat: add abilty to skip CD-ROM eject

### DIFF
--- a/builder/vsphere/common/step_remove_cdrom.go
+++ b/builder/vsphere/common/step_remove_cdrom.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
+	"github.com/hashicorp/packer-plugin-sdk/template/config"
 	"github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/driver"
 )
 
@@ -19,6 +20,10 @@ type RemoveCDRomConfig struct {
 	// Remove all CD-ROM devices from the virtual machine when the build is
 	// complete. Defaults to `false`.
 	RemoveCdrom bool `mapstructure:"remove_cdrom"`
+
+	// Eject all CD-ROM media from the CD-ROM devices when the build is
+	// complete. Defaults to `true`.
+	EjectCdrom config.Trilean `mapstructure:"eject_cdrom"`
 }
 
 type StepRemoveCDRom struct {
@@ -29,12 +34,18 @@ func (s *StepRemoveCDRom) Run(_ context.Context, state multistep.StateBag) multi
 	ui := state.Get("ui").(packersdk.Ui)
 	vm := state.Get("vm").(driver.VirtualMachine)
 
+	if s.Config.EjectCdrom == config.TriUnset {
+		s.Config.EjectCdrom = config.TriTrue
+	}
+
 	// Eject media from CD-ROM devices.
-	ui.Say("Ejecting CD-ROM media...")
-	err := vm.EjectCdroms()
-	if err != nil {
-		state.Put("error", fmt.Errorf("error ejecting cdrom media: %v", err))
-		return multistep.ActionHalt
+	if s.Config.EjectCdrom.True() {
+		ui.Say("Ejecting CD-ROM media...")
+		err := vm.EjectCdroms()
+		if err != nil {
+			state.Put("error", fmt.Errorf("error ejecting cdrom media: %v", err))
+			return multistep.ActionHalt
+		}
 	}
 
 	// Remove all CD-ROM devices from the image.


### PR DESCRIPTION
This is useful for situations where permissions to eject are not available to the current user (e.g. for cloning existing VMs where optical media may not be mounted for the build process)

**DELETE THIS PART BEFORE SUBMITTING**

In order to have a good experience with our community, we recommend that you
read the contributing guidelines for making a PR, and understand the lifecycle
of a Packer Plugin PR:

https://github.com/hashicorp/packer-plugin-vsphere/blob/main/.github/CONTRIBUTING.md#opening-an-pull-request

----

### Description
What code changed, and why?


### Resolved Issues
If your PR resolves any open issue(s), please indicate them like this so they will be closed when your PR is merged:

Closes #xxx
Closes #xxx

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
### Rollback Plan

If a change needs to be reverted, we will roll out an update to the code within 7 days.

### Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

